### PR TITLE
Attempt to adjust next sleep based on this sleep

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -48,13 +48,24 @@ fn main() {
         window.clear(Color::BLACK);
         window.draw(&rectangle);
         window.display();
-        let render_time = clock.split();
+        let render_time = clock.delta();
+        trace!(
+            ?render_time,
+            ?TARGET_RENDER_TIME,
+            ?adjust_time,
+            "Rendering complete"
+        );
         if let Some(intended_sleep_time) = TARGET_RENDER_TIME
             .checked_sub(render_time)
             .and_then(|sleep_time| sleep_time.checked_sub(adjust_time))
         {
+            trace!(?intended_sleep_time, "Sleeping");
             std::thread::sleep(intended_sleep_time);
-            // let adjust_time = actual_sleep_time - intended_sleep_time
+            let actual_sleep_time = clock.delta();
+            trace!(?actual_sleep_time, "Slept");
+            adjust_time = actual_sleep_time.saturating_sub(intended_sleep_time);
+        } else {
+            adjust_time = Duration::ZERO;
         }
     }
 }


### PR DESCRIPTION
## What?

Updates the `adjust_time` value to subtract from the next cycle's sleep in case we slept too long this time.

## Why?

In an attempt to keep the loops as consistent as possible. This helps in the following situation:

1. Render time takes 5ms.
2. We want to sleep 15ms.
3. We actually sleep 16ms because of OS stuff.
4. Next cycle, render time takes 5ms.
5. We would normally sleep 15ms, but we sleep 14ms.
6. Let's say that sleep goes perfectly at 14ms.

Now we've done a total of 5ms + 16ms + 5ms + 14ms = 40ms for two cycles, which is perfect!

## Testing

For testing, try running `RUST_LOG=trace cargo run` to view the trace logs and see that `adjust_time` is doing the right thing. I also locally played with updating the sleep line to be:

```rust
std::thread::sleep(intended_sleep_time + Duration::from_millis(whatever));
```

to play around with different values.

## Note

I'm unsure about clearing `adjust_time` in the case where we don't sleep at all. I'm pretty sure it's right, but not 100%.

## Note

As discussed on the call, we could move the `clock.delta()` to after the subtraction, just before the sleep. This would be "the most correct" and does match the guide, which is reasonable.